### PR TITLE
Move most generated code to runtime library

### DIFF
--- a/rpclib-test/project/plugins.sbt
+++ b/rpclib-test/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.thesamet"      % "sbt-protoc"      % "0.99.18")
-addSbtPlugin("com.tubitv.rpclib" % "rpclib-compiler" % "0.3.0")
+addSbtPlugin("com.tubitv.rpclib" % "rpclib-compiler" % "1.0.0")

--- a/rpclib/project/Common.scala
+++ b/rpclib/project/Common.scala
@@ -2,7 +2,7 @@ import sbt.Keys._
 
 object Common {
 
-  private final val RpclibVersion = "0.3.0"
+  private final val RpclibVersion = "1.0.0"
 
   lazy val settings =
     Seq(

--- a/rpclib/project/Libraries.scala
+++ b/rpclib/project/Libraries.scala
@@ -8,4 +8,5 @@ object Libraries {
   val grpcStub        = "io.grpc"               % "grpc-stub"        % grpcJavaVersion
   val reactiveStreams = "org.reactivestreams"   % "reactive-streams" % "1.0.2"
   val scalapbCompiler = "com.thesamet.scalapb" %% "compilerplugin"   % scalapbVersion
+  val scalapbGrpcRuntime = "com.thesamet.scalapb"   %% "scalapb-runtime-grpc" % scalapbVersion
 }

--- a/rpclib/project/Projects.scala
+++ b/rpclib/project/Projects.scala
@@ -57,7 +57,8 @@ object Projects {
         libraryDependencies ++= Seq(
           Libraries.akkaStreams,
           Libraries.grpcStub,
-          Libraries.reactiveStreams
+          Libraries.reactiveStreams,
+          Libraries.scalapbGrpcRuntime
         )
       )
 }

--- a/rpclib/src/compiler/src/main/scala/com/tubitv/rpclib/compiler/RpcLibCodeGenerator.scala
+++ b/rpclib/src/compiler/src/main/scala/com/tubitv/rpclib/compiler/RpcLibCodeGenerator.scala
@@ -2,7 +2,6 @@ package com.tubitv.rpclib.compiler
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
-
 import com.google.protobuf.Descriptors.Descriptor
 import com.google.protobuf.Descriptors.FileDescriptor
 import com.google.protobuf.Descriptors.MethodDescriptor
@@ -19,7 +18,8 @@ import scalapb.compiler.GeneratorParams
 import scalapb.compiler.NameUtils
 import scalapb.compiler.ProtoValidation
 import scalapb.compiler.StreamType
-import scalapb.compiler.Version.{ scalapbVersion => ScalaPbVersion }
+import scalapb.compiler.StreamType.{Bidirectional, ClientStreaming, ServerStreaming, Unary}
+import scalapb.compiler.Version.{scalapbVersion => ScalaPbVersion}
 import scalapb.options.compiler.Scalapb
 
 object RpcLibCodeGenerator extends ProtocCodeGenerator {
@@ -337,71 +337,22 @@ private class RpcLibCodeGenerator(val service: ServiceDescriptor, override val p
         private def addStubMethodImplementations(printer: FunctionalPrinter, method: MethodDescriptor): FunctionalPrinter = {
           def addBody(printer: FunctionalPrinter): FunctionalPrinter = {
             method.streamType match {
-              case StreamType.Unary =>
-                printer
-                  .add(s"Flow[${method.scalaIn}].flatMapConcat(request =>")
-                  .indent
-                  .add("Source.fromFuture(")
-                  .indent
-                  .add("Grpc.guavaFuture2ScalaFuture(")
-                  .indent
-                  .add("ClientCalls.futureUnaryCall(")
-                  .indent
-                  .add(s"channelWithHeaders.newCall(Method${method.getName}, options.withOption(EnvoyHeadersClientInterceptor.HeadersKey, envoyHeaders)),")
-                  .add("request")
-                  .outdent
-                  .add(")")
-                  .outdent
-                  .add(")")
-                  .outdent
-                  .add(")")
-                  .outdent
-                  .add(")")
-
-              case StreamType.ServerStreaming =>
-                printer
-                  .add("Flow.fromGraph(")
-                  .indent
-                  .add(s"new GrpcGraphStage[${method.scalaIn}, ${method.scalaOut}]({ outputObserver =>")
-                  .indent
-                  .add(s"new StreamObserver[${method.scalaIn}] {")
-                  .indent
-                  .add("override def onError(t: Throwable): Unit = ()")
-                  .add("override def onCompleted(): Unit = ()")
-                  .add(s"override def onNext(request: ${method.scalaIn}): Unit = {")
-                  .indent
-                  .add("ClientCalls.asyncServerStreamingCall(")
-                  .indent
-                  .add(s"channelWithHeaders.newCall(Method${method.getName}, options.withOption(EnvoyHeadersClientInterceptor.HeadersKey, envoyHeaders)),")
-                  .add("request,")
-                  .add("outputObserver")
-                  .outdent
-                  .add(")")
-                  .outdent
-                  .add("}")
-                  .outdent
-                  .add("}")
-                  .outdent
-                  .add("})")
-                  .outdent
-                  .add(")")
-
-              case StreamType.ClientStreaming | StreamType.Bidirectional =>
-                printer
-                  .add("Flow.fromGraph(")
-                  .indent
-                  .add(s"new GrpcGraphStage[${method.scalaIn}, ${method.scalaOut}]({ outputObserver =>")
-                  .indent
-                  .add("ClientCalls.asyncClientStreamingCall(")
-                  .indent
-                  .add(s"channelWithHeaders.newCall(Method${method.getName}, options.withOption(EnvoyHeadersClientInterceptor.HeadersKey, envoyHeaders)),")
-                  .add("outputObserver")
-                  .outdent
-                  .add(")")
-                  .outdent
-                  .add("})")
-                  .outdent
-                  .add(")")
+              case Unary => printer
+                .add(s"GrpcAkkaStreamsClientCalls.unaryFlow[${method.scalaIn}, ${method.scalaOut}](")
+                .addIndented(s"channelWithHeaders.newCall(Method${method.getName}, options.withOption(EnvoyHeadersClientInterceptor.HeadersKey, envoyHeaders))")
+                .add(")")
+              case ServerStreaming => printer
+                .add(s"GrpcAkkaStreamsClientCalls.serverStreamingFlow[${method.scalaIn}, ${method.scalaOut}](")
+                .addIndented(s"channelWithHeaders.newCall(Method${method.getName}, options.withOption(EnvoyHeadersClientInterceptor.HeadersKey, envoyHeaders))")
+                .add(")")
+              case ClientStreaming => printer
+                .add(s"GrpcAkkaStreamsClientCalls.clientStreamingFlow[${method.scalaIn}, ${method.scalaOut}](")
+                .addIndented(s"channelWithHeaders.newCall(Method${method.getName}, options.withOption(EnvoyHeadersClientInterceptor.HeadersKey, envoyHeaders))")
+                .add(")")
+              case Bidirectional => printer
+                .add(s"GrpcAkkaStreamsClientCalls.bidiStreamingFlow[${method.scalaIn}, ${method.scalaOut}](")
+                .addIndented(s"channelWithHeaders.newCall(Method${method.getName}, options.withOption(EnvoyHeadersClientInterceptor.HeadersKey, envoyHeaders))")
+                .add(")")
             }
           }
 
@@ -494,68 +445,23 @@ private class RpcLibCodeGenerator(val service: ServiceDescriptor, override val p
     private def addBindServiceMethod(printer: FunctionalPrinter): FunctionalPrinter = {
       def addMethodCall(printer: FunctionalPrinter, method: MethodDescriptor): FunctionalPrinter = {
         def addBody(printer: FunctionalPrinter): FunctionalPrinter = {
-          val methodType = method.streamType match {
-            case StreamType.Unary => "Unary"
-            case StreamType.ServerStreaming => "ServerStreaming"
-            case StreamType.ClientStreaming => "ClientStreaming"
-            case StreamType.Bidirectional => "BidiStreaming"
-          }
-
           method.streamType match {
-            case StreamType.Unary | StreamType.ServerStreaming =>
+            case StreamType.Unary =>
               printer
                 .add(s"Method${method.getName},")
-                .add(s"ServerCalls.async${methodType}Call(")
-                .indent
-                .add(s"new ServerCalls.${methodType}Method[${method.scalaIn}, ${method.scalaOut}] {")
-                .indent
-                .add(s"override def invoke(request: ${method.scalaIn}, responseObserver: StreamObserver[${method.scalaOut}]) = {")
-                .indent
-                .add("Source.single(request)")
-                .indent
-                .add(s".via(serviceImpl.${method.name}(EnvoyHeadersServerInterceptor.ContextKey.get(Context.current)))")
-                .add(".runForeach(responseObserver.onNext)")
-                .add(".onComplete {")
-                .indent
-                .add("case Success(_) => responseObserver.onCompleted()")
-                .add("case Failure(t) => responseObserver.onError(io.grpc.Status.fromThrowable(t).asException)")
-                .outdent
-                .add("}(mat.executionContext)")
-                .outdent
-                .outdent
-                .add("}")
-                .outdent
-                .add("}")
-                .outdent
-                .add(")")
-
-            case StreamType.ClientStreaming | StreamType.Bidirectional =>
+                .add(s"GrpcAkkaStreamsServerCalls.unaryCall(serviceImpl.${method.name}(EnvoyHeadersServerInterceptor.ContextKey.get(Context.current)))")
+            case StreamType.ClientStreaming =>
               printer
                 .add(s"Method${method.getName},")
-                .add(s"ServerCalls.async${methodType}Call(")
-                .indent
-                .add(s"new ServerCalls.${methodType}Method[${method.scalaIn}, ${method.scalaOut}] {")
-                .indent
-                .add(s"override def invoke(responseObserver: StreamObserver[${method.scalaOut}]): StreamObserver[${method.scalaIn}] = {")
-                .indent
-                .add("// blocks until the `GraphStage` is fully initialized")
-                .add("Await.result(")
-                .indent
-                .add(s"Source.fromGraph(new GrpcSourceStage[${method.scalaIn}])")
-                .indent
-                .add(s".via(serviceImpl.${method.name}(EnvoyHeadersServerInterceptor.ContextKey.get(Context.current)))")
-                .add(".to(Sink.fromSubscriber(grpcObserverToReactiveSubscriber(responseObserver)))")
-                .add(".run(),")
-                .outdent
-                .add("5.seconds")
-                .outdent
-                .add(")")
-                .outdent
-                .add("}")
-                .outdent
-                .add("}")
-                .outdent
-                .add(")")
+                .add(s"GrpcAkkaStreamsServerCalls.clientStreamingCall(serviceImpl.${method.name}(EnvoyHeadersServerInterceptor.ContextKey.get(Context.current)))")
+            case StreamType.ServerStreaming =>
+              printer
+                .add(s"Method${method.getName},")
+                .add(s"GrpcAkkaStreamsServerCalls.serverStreamingCall(serviceImpl.${method.name}(EnvoyHeadersServerInterceptor.ContextKey.get(Context.current)))")
+            case StreamType.Bidirectional =>
+              printer
+              .add(s"Method${method.getName},")
+              .add(s"GrpcAkkaStreamsServerCalls.bidiStreamingCall(serviceImpl.${method.name}(EnvoyHeadersServerInterceptor.ContextKey.get(Context.current)))")
           }
         }
 

--- a/rpclib/src/compiler/src/main/scala/com/tubitv/rpclib/compiler/RpcLibCodeGenerator.scala
+++ b/rpclib/src/compiler/src/main/scala/com/tubitv/rpclib/compiler/RpcLibCodeGenerator.scala
@@ -190,6 +190,7 @@ private class RpcLibCodeGenerator(val service: ServiceDescriptor, override val p
         "com.tubitv.rpclib.runtime.FailurePolicy.Fallthrough",
         "com.tubitv.rpclib.runtime.FailurePolicy.RetryPolicy",
         "com.tubitv.rpclib.runtime.GrpcAkkaStreams._",
+        "com.tubitv.rpclib.runtime.{GrpcAkkaStreamsClientCalls, GrpcAkkaStreamsServerCalls}",
         "com.tubitv.rpclib.runtime.headers.EnvoyHeaders",
         "com.tubitv.rpclib.runtime.interceptors.EnvoyHeadersClientInterceptor",
         "com.tubitv.rpclib.runtime.interceptors.EnvoyHeadersServerInterceptor",

--- a/rpclib/src/compiler/src/main/scala/com/tubitv/rpclib/compiler/package.scala
+++ b/rpclib/src/compiler/src/main/scala/com/tubitv/rpclib/compiler/package.scala
@@ -7,7 +7,7 @@ import protocbridge.JvmGenerator
 package object compiler {
 
   /** TODO(dan): Scaladoc */
-  final val RpclibVersion = "0.3.0"
+  final val RpclibVersion = "1.0.0"
 
   /** Entry point for Scala RPC wrapper compiler plugin.
    *

--- a/rpclib/src/runtime/src/main/scala/com/tubitv/rpclib/runtime/GrpcAkkaStreamsClientCalls.scala
+++ b/rpclib/src/runtime/src/main/scala/com/tubitv/rpclib/runtime/GrpcAkkaStreamsClientCalls.scala
@@ -1,0 +1,22 @@
+package com.tubitv.rpclib.runtime
+
+import akka.NotUsed
+import akka.stream.scaladsl.{Flow, Source}
+import io.grpc.ClientCall
+import io.grpc.stub.ClientCalls
+import scalapb.grpc.Grpc
+
+object GrpcAkkaStreamsClientCalls {
+
+  def unaryFlow[Req, Resp](call: ClientCall[Req, Resp]): Flow[Req, Resp, NotUsed] = {
+    Flow[Req].flatMapConcat(req => {
+      Source.fromFuture(Grpc.guavaFuture2ScalaFuture(ClientCalls.futureUnaryCall(call, req)))
+    })
+  }
+
+  def serverStreamingFlow[Req, Resp](call: ClientCall[Req, Resp]): Flow[Req, Resp, NotUsed] = ???
+
+  def clientStreamingFlow[Req, Resp](call: ClientCall[Req, Resp]): Flow[Req, Resp, NotUsed] = ???
+
+  def bidiStreamingFlow[Req, Resp](call: ClientCall[Req, Resp]): Flow[Req, Resp, NotUsed] = ???
+}

--- a/rpclib/src/runtime/src/main/scala/com/tubitv/rpclib/runtime/GrpcAkkaStreamsClientCalls.scala
+++ b/rpclib/src/runtime/src/main/scala/com/tubitv/rpclib/runtime/GrpcAkkaStreamsClientCalls.scala
@@ -1,22 +1,71 @@
 package com.tubitv.rpclib.runtime
 
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+
 import akka.NotUsed
 import akka.stream.scaladsl.{Flow, Source}
-import io.grpc.ClientCall
-import io.grpc.stub.ClientCalls
+import io.grpc.{ClientCall, Metadata, Status}
+import io.grpc.stub.{ClientCallStreamObserver, ClientCalls, ClientResponseObserver}
 import scalapb.grpc.Grpc
 
 object GrpcAkkaStreamsClientCalls {
 
   def unaryFlow[Req, Resp](call: ClientCall[Req, Resp]): Flow[Req, Resp, NotUsed] = {
     Flow[Req].flatMapConcat(req => {
-      Source.fromFuture(Grpc.guavaFuture2ScalaFuture(ClientCalls.futureUnaryCall(call, req)))
+      Source.fromFuture(
+        Grpc.guavaFuture2ScalaFuture(
+          ClientCalls.futureUnaryCall(call, req)
+        )
+      )
     })
   }
 
-  def serverStreamingFlow[Req, Resp](call: ClientCall[Req, Resp]): Flow[Req, Resp, NotUsed] = ???
+  def serverStreamingFlow[Req, Resp](call: ClientCall[Req, Resp]): Flow[Req, Resp, NotUsed] =
+    Flow.fromGraph(
+      new GrpcGraphStage[Req, Resp](outputObserver => {
+        val out = outputObserver.asInstanceOf[ClientResponseObserver[Req, Resp]]
+        val in = new ClientCallStreamObserver[Req] {
+          val halfClosed = new AtomicBoolean(false)
+          val onReadyHandler = new AtomicReference[Option[Runnable]](None)
+          val listener = new ClientCall.Listener[Resp] {
+            override def onClose(status: Status, trailers: Metadata): Unit =
+              status.getCode match {
+                case Status.Code.OK => out.onCompleted()
+                case _ => out.onError(status.asException(trailers))
+              }
+            override def onMessage(message: Resp): Unit =
+              out.onNext(message)
+            override def onReady(): Unit =
+              onReadyHandler.get().foreach(_.run())
+          }
+          call.start(listener, new Metadata())
 
-  def clientStreamingFlow[Req, Resp](call: ClientCall[Req, Resp]): Flow[Req, Resp, NotUsed] = ???
+          override def cancel(message: String, cause: Throwable): Unit =
+            call.cancel(message, cause)
+          override def setOnReadyHandler(onReadyHandler: Runnable): Unit =
+            this.onReadyHandler.set(Some(onReadyHandler))
+          override def request(count: Int): Unit = call.request(count)
+          override def disableAutoInboundFlowControl(): Unit = ()
+          override def isReady: Boolean = !halfClosed.get() || call.isReady
+          override def setMessageCompression(enable: Boolean): Unit =
+            call.setMessageCompression(enable)
+          override def onError(t: Throwable): Unit =
+            call.cancel("Cancelled by client with StreamObserver.onError()", t)
+          override def onCompleted(): Unit = ()
+          override def onNext(request: Req): Unit = {
+            call.sendMessage(request)
+            halfClosed.set(true)
+            call.halfClose()
+          }
+        }
+        out.beforeStart(in)
+        in
+      })
+    )
 
-  def bidiStreamingFlow[Req, Resp](call: ClientCall[Req, Resp]): Flow[Req, Resp, NotUsed] = ???
+  def clientStreamingFlow[Req, Resp](call: ClientCall[Req, Resp]): Flow[Req, Resp, NotUsed] =
+    Flow.fromGraph(new GrpcGraphStage[Req, Resp](ClientCalls.asyncClientStreamingCall(call, _)))
+
+  def bidiStreamingFlow[Req, Resp](call: ClientCall[Req, Resp]): Flow[Req, Resp, NotUsed] =
+    Flow.fromGraph(new GrpcGraphStage[Req, Resp](ClientCalls.asyncBidiStreamingCall(call, _)))
 }

--- a/rpclib/src/runtime/src/main/scala/com/tubitv/rpclib/runtime/GrpcAkkaStreamsServerCalls.scala
+++ b/rpclib/src/runtime/src/main/scala/com/tubitv/rpclib/runtime/GrpcAkkaStreamsServerCalls.scala
@@ -1,0 +1,13 @@
+package com.tubitv.rpclib.runtime
+
+import akka.stream.scaladsl.Flow
+import io.grpc.ServerCallHandler
+
+object GrpcAkkaStreamsServerCalls {
+
+  def unaryCall[Req, Resp, NotUsed](flow: Flow[Req, Resp, NotUsed]): ServerCallHandler[Req, Resp] = ???
+  def serverStreamingCall[Req, Resp, NotUsed](flow: Flow[Req, Resp, NotUsed]): ServerCallHandler[Req, Resp] = ???
+  def clientStreamingCall[Req, Resp, NotUsed](flow: Flow[Req, Resp, NotUsed]): ServerCallHandler[Req, Resp] = ???
+  def bidiStreamingCall[Req, Resp, NotUsed](flow: Flow[Req, Resp, NotUsed]): ServerCallHandler[Req, Resp] = ???
+
+}

--- a/rpclib/src/runtime/src/main/scala/com/tubitv/rpclib/runtime/GrpcAkkaStreamsServerCalls.scala
+++ b/rpclib/src/runtime/src/main/scala/com/tubitv/rpclib/runtime/GrpcAkkaStreamsServerCalls.scala
@@ -1,13 +1,87 @@
 package com.tubitv.rpclib.runtime
 
-import akka.stream.scaladsl.Flow
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Flow, Sink, Source}
 import io.grpc.ServerCallHandler
+import io.grpc.stub.{CallStreamObserver, ServerCalls, StreamObserver}
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.util.{Failure, Success}
 
 object GrpcAkkaStreamsServerCalls {
 
-  def unaryCall[Req, Resp, NotUsed](flow: Flow[Req, Resp, NotUsed]): ServerCallHandler[Req, Resp] = ???
-  def serverStreamingCall[Req, Resp, NotUsed](flow: Flow[Req, Resp, NotUsed]): ServerCallHandler[Req, Resp] = ???
-  def clientStreamingCall[Req, Resp, NotUsed](flow: Flow[Req, Resp, NotUsed]): ServerCallHandler[Req, Resp] = ???
-  def bidiStreamingCall[Req, Resp, NotUsed](flow: Flow[Req, Resp, NotUsed]): ServerCallHandler[Req, Resp] = ???
+  def unaryCall[Req, Resp, NotUsed](service: Flow[Req, Resp, NotUsed])(
+    implicit mat: Materializer
+  ): ServerCallHandler[Req, Resp] =
+    ServerCalls.asyncUnaryCall(
+      new ServerCalls.UnaryMethod[Req, Resp] {
+        override def invoke(request: Req, responseObserver: StreamObserver[Resp]) =
+          Source
+            .single(request)
+            .via(service)
+            .runForeach(responseObserver.onNext)
+            .onComplete {
+              case Success(_) => responseObserver.onCompleted()
+              case Failure(err) => responseObserver.onError(err)
+            }(mat.executionContext)
+      }
+    )
 
+  def serverStreamingCall[Req, Resp, NotUsed](service: Flow[Req, Resp, NotUsed])(
+    implicit mat: Materializer
+  ): ServerCallHandler[Req, Resp] =
+    ServerCalls.asyncServerStreamingCall(
+      new ServerCalls.ServerStreamingMethod[Req, Resp] {
+        override def invoke(request: Req, responseObserver: StreamObserver[Resp]): Unit =
+          Source
+            .single(request)
+            .via(service)
+            .runWith(Sink.fromGraph(new GrpcSinkStage[Resp](
+              responseObserver.asInstanceOf[CallStreamObserver[Resp]]
+            )))
+      }
+    )
+
+  def clientStreamingCall[Req, Resp, NotUsed](service: Flow[Req, Resp, NotUsed])(
+    implicit mat: Materializer
+  ): ServerCallHandler[Req, Resp] =
+    ServerCalls.asyncClientStreamingCall(
+      new ServerCalls.ClientStreamingMethod[Req, Resp] {
+        override def invoke(responseObserver: StreamObserver[Resp]): StreamObserver[Req] =
+        // blocks until the GraphStage is fully initialized
+          Await.result(
+            Source
+              .fromGraph(new GrpcSourceStage[Req, Resp](
+                responseObserver.asInstanceOf[CallStreamObserver[Resp]]
+              ))
+              .via(service)
+              .to(Sink.fromGraph(new GrpcSinkStage[Resp](
+                responseObserver.asInstanceOf[CallStreamObserver[Resp]]
+              ))).run(),
+            Duration.Inf
+          )
+      }
+    )
+
+  def bidiStreamingCall[Req, Resp, NotUsed](service: Flow[Req, Resp, NotUsed])(
+    implicit mat: Materializer
+  ): ServerCallHandler[Req, Resp] =
+    ServerCalls.asyncBidiStreamingCall(
+      new ServerCalls.BidiStreamingMethod[Req, Resp] {
+        override def invoke(responseObserver: StreamObserver[Resp]): StreamObserver[Req] =
+        // blocks until the GraphStage is fully initialized
+          Await.result(
+            Source
+              .fromGraph(new GrpcSourceStage[Req, Resp](
+                responseObserver.asInstanceOf[CallStreamObserver[Resp]]
+              ))
+              .via(service)
+              .to(Sink.fromGraph(new GrpcSinkStage[Resp](
+                responseObserver.asInstanceOf[CallStreamObserver[Resp]]
+              ))).run(),
+            Duration.Inf
+          )
+      }
+    )
 }

--- a/rpclib/src/runtime/src/main/scala/com/tubitv/rpclib/runtime/GrpcGraphStage.scala
+++ b/rpclib/src/runtime/src/main/scala/com/tubitv/rpclib/runtime/GrpcGraphStage.scala
@@ -1,0 +1,77 @@
+package com.tubitv.rpclib.runtime
+
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import com.tubitv.rpclib.runtime.GrpcAkkaStreams.GrpcOperator
+import io.grpc.stub.{ClientCallStreamObserver, ClientResponseObserver}
+
+class GrpcGraphStage[Req, Resp](operator: GrpcOperator[Req, Resp]) extends GraphStage[FlowShape[Req, Resp]] {
+  val in = Inlet[Req]("grpc.in")
+  val out = Outlet[Resp]("grpc.out")
+
+  override val shape: FlowShape[Req, Resp] = FlowShape.of(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+
+      var requestStream = new AtomicReference[Option[ClientCallStreamObserver[Req]]](None)
+      val element = new AtomicReference[Option[Req]](None)
+      val requested = new AtomicBoolean(false)
+
+      val outObs = new ClientResponseObserver[Req, Resp] with Runnable {
+        override def beforeStart(reqStream: ClientCallStreamObserver[Req]): Unit = {
+          requestStream.set(Some(reqStream))
+          reqStream.disableAutoInboundFlowControl()
+          reqStream.setOnReadyHandler(this)
+        }
+
+        override def onError(t: Throwable) =
+          getAsyncCallback((t: Throwable) => fail(out, t)).invoke(t)
+
+        override def onCompleted() =
+          getAsyncCallback((_: Unit) => complete(out)).invoke(())
+
+        override def onNext(value: Resp) =
+          getAsyncCallback((value: Resp) => push(out, value)).invoke(value)
+
+        override def run(): Unit = requestStream.get().foreach { reqStream =>
+          if (requested.compareAndSet(true, false)) reqStream.request(1)
+          if (reqStream.isReady) {
+            element.getAndSet(None).foreach { value =>
+              reqStream.onNext(value)
+              tryPull(in)
+            }
+          }
+        }
+      }
+
+      val inObs = operator(outObs)
+
+      override def onPush(): Unit = {
+        val value = grab(in)
+        requestStream.get() match {
+          case Some(reqStream) if reqStream.isReady() =>
+            reqStream.onNext(value)
+            pull(in)
+          case _ => element.compareAndSet(None, Some(value))
+        }
+      }
+
+      override def onUpstreamFinish(): Unit = inObs.onCompleted()
+
+      override def onUpstreamFailure(t: Throwable): Unit = inObs.onError(t)
+
+      override def onPull(): Unit =
+        requestStream.get() match {
+          case Some(reqStream) => reqStream.request(1)
+          case _ => requested.compareAndSet(false, true)
+        }
+
+      override def preStart(): Unit = pull(in)
+
+      setHandler(in, this)
+      setHandler(out, this)
+    }
+}

--- a/rpclib/src/runtime/src/main/scala/com/tubitv/rpclib/runtime/GrpcSinkStage.scala
+++ b/rpclib/src/runtime/src/main/scala/com/tubitv/rpclib/runtime/GrpcSinkStage.scala
@@ -1,0 +1,40 @@
+package com.tubitv.rpclib.runtime
+
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler}
+import akka.stream.{Attributes, Inlet, SinkShape}
+import io.grpc.stub.CallStreamObserver
+
+class GrpcSinkStage[Resp](observer: CallStreamObserver[Resp]) extends GraphStage[SinkShape[Resp]] {
+  val in = Inlet[Resp]("grpc.in")
+  override val shape: SinkShape[Resp] = SinkShape.of(in)
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with InHandler with Runnable {
+      var element: Option[Resp] = None
+
+      override def run(): Unit = getAsyncCallback((_: Unit) => {
+        element match {
+          case Some(value) if observer.isReady =>
+            observer.onNext(value)
+            tryPull(in)
+          case _ => ()
+        }
+      }).invoke(())
+
+      override def onPush(): Unit = {
+        val value = grab(in)
+        if (observer.isReady) {
+          observer.onNext(value)
+          pull(in)
+        } else element = Some(value)
+      }
+
+      override def onUpstreamFinish(): Unit = observer.onCompleted()
+
+      override def onUpstreamFailure(t: Throwable): Unit = observer.onError(t)
+
+      override def preStart(): Unit = pull(in)
+
+      observer.setOnReadyHandler(this)
+      setHandler(in, this)
+    }
+}

--- a/rpclib/src/runtime/src/main/scala/com/tubitv/rpclib/runtime/GrpcSourceStage.scala
+++ b/rpclib/src/runtime/src/main/scala/com/tubitv/rpclib/runtime/GrpcSourceStage.scala
@@ -1,0 +1,43 @@
+package com.tubitv.rpclib.runtime
+
+import akka.stream.{Attributes, Outlet, SourceShape}
+import akka.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, OutHandler}
+import io.grpc.stub.{CallStreamObserver, StreamObserver}
+
+import scala.concurrent.{Future, Promise}
+
+class GrpcSourceStage[Req, Resp](requestStream: CallStreamObserver[Resp])
+  extends GraphStageWithMaterializedValue[SourceShape[Req], Future[StreamObserver[Req]]] {
+  val out = Outlet[Req]("grpc.out")
+  override val shape: SourceShape[Req] = SourceShape.of(out)
+
+  override def createLogicAndMaterializedValue(
+                                                inheritedAttributes: Attributes
+                                              ): (GraphStageLogic, Future[StreamObserver[Req]]) = {
+    val promise: Promise[StreamObserver[Req]] = Promise()
+
+    val logic = new GraphStageLogic(shape) with OutHandler {
+      val inObs = new StreamObserver[Req] {
+        override def onError(t: Throwable) =
+          getAsyncCallback((t: Throwable) => fail(out, t)).invoke(t)
+
+        override def onCompleted() =
+          getAsyncCallback((_: Unit) => complete(out)).invoke(())
+
+        override def onNext(value: Req) =
+          getAsyncCallback((value: Req) => push(out, value)).invoke(value)
+      }
+
+      override def onPull(): Unit = requestStream.request(1)
+
+      override def preStart(): Unit = {
+        requestStream.disableAutoInboundFlowControl()
+        promise.success(inObs)
+      }
+
+      setHandler(out, this)
+    }
+
+    (logic, promise.future)
+  }
+}


### PR DESCRIPTION
* Move most generated code to runtime library to easy of modification
* Add patches from https://github.com/btlines/grpcakkastream to fix potential `afterPostStop` exceptions